### PR TITLE
Cambio de los accesos del Roboticista

### DIFF
--- a/maps/torch/job/engineering_jobs.dm
+++ b/maps/torch/job/engineering_jobs.dm
@@ -177,7 +177,7 @@
 	selection_color = "#5b4d20"
 	economic_power = 6
 	alt_titles = list(
-		"Mechsuit Technician")
+		"Mechsuit Technician","Biomechanical Engineer","Mechatronic Engineer")
 	outfit_type = /decl/hierarchy/outfit/job/torch/crew/engineering/roboticist
 	allowed_branches = list(
 		/datum/mil_branch/expeditionary_corps = /decl/hierarchy/outfit/job/torch/crew/engineering/roboticistec,
@@ -207,7 +207,9 @@
 	skill_points = 20
 
 	access = list(
-		access_robotics, access_engine, access_solgov_crew, access_network, access_radio_eng
+		access_robotics, access_engine, access_solgov_crew, access_network, access_radio_eng, access_engine_equip,
+		access_maint_tunnels, access_external_airlocks, access_emergency_storage, access_eva, access_janitor,
+		access_construction, access_hangar, access_tech_storage
 	)
 
 /datum/job/roboticist/get_description_blurb()


### PR DESCRIPTION
<!-- 
Do not forget to add a changelog when you have made admin/player facing changes that can alter gameplay.
Examples which require a changelog entry include:
* Adding/removing objects that players may interact with, or the way they function.
* Adding/removing/altering admin tools.
* Changing the map.

Examples were changelog entries are optional/not typically required:
* Cosmetic changes such as descriptions, sound effects, etc.
* Optimizations and other changes to underlying systems which do not affect gameplay.
* Minor bug fixes.

You'll find a README and example file in .\html\changelogs\ for further instructions.

You can also find a template for adding your changelog directly to the PR description here: https://github.com/Baystation12/Baystation12/wiki/Automatic-changelog-generation
-->
Cambio de los accesos del roboticista para que tengan id al nivel de un ingeniero en entrenamiento(engineer trainee) y agrega 2 titulos alternativos del roboticista antiguos que no fueron colocados en el nuevo job.

POR QUE?

Por que con la falta de ingenieros y la abundancia de roboticistas que ya son parte de ingenieria, esto les puede permitir al menos montar los motores al inicio de ronda para beneficio de todos.